### PR TITLE
Make table responsive on phones

### DIFF
--- a/source/index.liquid
+++ b/source/index.liquid
@@ -18,19 +18,19 @@ layout: layout
 <table class="images--container">
   <thead>
     <tr>
-      <th class="images--sort-trigger" data-sorted="asc">Name</th>
-      <th>Thumbnail</th>
-      <th class="images--sort-trigger">Date</th>
+      <th class="images--sort-trigger images--image-name" data-sorted="asc">Name</th>
+      <th class="images--image-thumbnail">Thumbnail</th>
+      <th class="images--sort-trigger images--image-date">Date</th>
     </tr>
   </thead>
   <tbody>
     {% for image in bucket.images %}
       <tr class="images--image" data-name="{{ image.name }}" data-type="{{ image.type }}">
-        <td>
+        <td class="images--image-name">
           <a href="/{{ image.name }}">{{ image.name }}</a>
         </td>
 
-        <td>
+        <td class="images--image-thumbnail">
           <a href="/{{ image.name }}">
             <img src="{{ image.thumbnail.url }}"
                  loading="lazy"
@@ -40,7 +40,7 @@ layout: layout
           </a>
         </td>
 
-        <td>
+        <td class="images--image-date">
           {{ image.date | date: "%Y-%m-%d" }}
         </td>
       </tr>

--- a/source/stylesheets/site.css
+++ b/source/stylesheets/site.css
@@ -23,13 +23,38 @@
 .images--container {
   @apply m-4;
 
-  & th, & td {
-    @apply pr-1;
-    @apply pb-1;
+  & tr {
+    @apply flex;
+    @apply flex-wrap;
+    @apply justify-between;
+    @apply md:table-row;
+
+    @apply my-1.5;
+    @apply md:m-0;
+
+    & th, & td {
+      @apply block;
+      @apply md:table-cell;
+    }
+
+    & th.images--image-thumbnail {
+      @apply hidden;
+      @apply md:table-cell;
+    }
+
+    & td.images--image-name {
+      @apply basis-full;
+    }
   }
 
-
   & th {
+    @apply pb-1;
+    @apply pr-1;
     @apply text-left;
+  }
+
+  & td {
+    @apply pb-1;
+    @apply pr-1;
   }
 }


### PR DESCRIPTION
Because:

* Now that there are some longer file names—I'm looking at you, fullyautomatedluxurygayspacecommunism.png—the preview images are getting pushed off the right side of mobile screens.

Solution:

* Make the table responsive!
* On small screens, use flexbox to put the name across the width of the screen and the thumbnail & date below, justified to the edges of the screen.
* But keep the typical table on larger screens.