### PR TITLE
Still, square thumbnails

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -18,9 +18,9 @@ module.exports = function(eleventyConfig) {
     },
   })
 
-  eleventyConfig.addGlobalData("filesDomain", "https://bucket-files.byrne.team")
-  eleventyConfig.addGlobalData("deployDomain", "https://bucket.patrickbyrne.net")
-  eleventyConfig.addGlobalData("sourceJSON", "https://bucket-files.byrne.team/bucket.json")
+  eleventyConfig.addGlobalData("filesDomain", process.env.FILES_DOMAIN)
+  eleventyConfig.addGlobalData("deployDomain", process.env.DEPLOY_DOMAIN)
+  eleventyConfig.addGlobalData("sourceJSON", process.env.DATA_JSON_URL)
 
   return {
     dir: { input: "source", output: "_site" }

--- a/bin/generate-thumbnails
+++ b/bin/generate-thumbnails
@@ -14,6 +14,7 @@ if [ ! -d "$ORIGINALS_BASE" ]; then
 fi
 
 mkdir -p $THUMBNAILS_BASE
+mkdir -p $STILL_CROPS_BASE
 
 for file in $(ls $ORIGINALS_BASE); do
   extension="${file##*.}"
@@ -26,8 +27,11 @@ for file in $(ls $ORIGINALS_BASE); do
       ;;
     *)
       echo "  using magick"
-      magick convert $ORIGINALS_BASE/$file -resize "${THUMBNAIL_SIZE}x${THUMBNAIL_SIZE}" -coalesce $THUMBNAILS_BASE/$file
+      magick convert $ORIGINALS_BASE/$file -resize "${THUMBNAIL_SIZE}x${THUMBNAIL_SIZE}" $THUMBNAILS_BASE/$file
   esac
+
+  echo "Generating ${file} still crop…"
+  magick convert "$ORIGINALS_BASE/$file[0]" -resize "${THUMBNAIL_SIZE}x${THUMBNAIL_SIZE}^" -extent "${THUMBNAIL_SIZE}x${THUMBNAIL_SIZE}" -gravity center $STILL_CROPS_BASE/$file
 done
 
 echo "Done!"

--- a/bin/update-json
+++ b/bin/update-json
@@ -46,10 +46,19 @@ originals.each do |original|
 
   thumb = Pathname.new(ENV.fetch("THUMBNAILS_BASE")).join(original.basename)
   thumb_dimensions = dimensions_of(thumb)
-  image_hash.fetch("thumbnails")["w#{ENV.fetch("THUMBNAIL_SIZE")}"] = {
+  image_hash.delete("thumbnails")
+  image_hash["thumbnail"] = {
     width: thumb_dimensions.width,
     height: thumb_dimensions.height,
     path: thumb.relative_path_from(base),
+  }
+
+  still = Pathname.new(ENV.fetch("STILL_CROPS_BASE")).join(original.basename)
+  still_dimensions = dimensions_of(still)
+  image_hash["still"] = {
+    width: still_dimensions.width,
+    height: still_dimensions.height,
+    path: still.relative_path_from(base),
   }
 end
 

--- a/lib/bucket-image.js
+++ b/lib/bucket-image.js
@@ -20,12 +20,25 @@ module.exports = class BucketImage {
   }
 
   get thumbnail() {
-    const size = "w160"
-    const thumb = this.record.thumbnails[size]
-    const height = thumb?.height || this.record.height
-    const width = thumb?.width || this.record.width
-    const path = thumb?.path || this.record.path
-    const source = thumb?.path
+    const height = this.record.thumbnail.height
+    const width = this.record.thumbnail.width
+    const path = this.record.thumbnail.path
+    const source = this.record.thumbnail.path
+
+    return {
+      height,
+      path,
+      source,
+      url: path,
+      width,
+    }
+  }
+
+  get still() {
+    const height = this.record.still.height
+    const width = this.record.still.width
+    const path = this.record.still.path
+    const source = this.record.still.path
 
     return {
       height,

--- a/lib/bucket.js
+++ b/lib/bucket.js
@@ -7,7 +7,7 @@ module.exports = class Bucket {
   images = []
 
   constructor({jsonURL} = {}) {
-    this.jsonURL = jsonURL || "https://bucket-files.byrne.team/bucket.json"
+    this.jsonURL = jsonURL || process.env.DATA_JSON_URL
   }
 
   async fetchPage() {

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,3 +3,8 @@ publish = "_site"
 
 [build.environment]
 NODE_VERSION = "18.17.1"
+
+[dev]
+command = "make serve"
+port = 8000
+targetPort = 8080

--- a/package-lock.json
+++ b/package-lock.json
@@ -303,9 +303,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.15.tgz",
+      "integrity": "sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1273,9 +1273,9 @@
       }
     },
     "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -3092,9 +3092,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.15.tgz",
+      "integrity": "sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ=="
     },
     "@babel/parser": {
       "version": "7.16.12",
@@ -3675,9 +3675,9 @@
       }
     },
     "fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",

--- a/source/_redirects.11ty.js
+++ b/source/_redirects.11ty.js
@@ -2,7 +2,7 @@ class Redirects {
   data() {
     return {
       permalink: (data) => {
-        return "public/_redirects"
+        return "_redirects"
       },
     }
   }
@@ -12,6 +12,7 @@ class Redirects {
     const redirects = []
     data.bucket.images.map((image) => {
       redirects.push(`/${image.original.url} ${data.filesDomain}/${image.original.source} 200`)
+      redirects.push(`/${image.still.url} ${data.filesDomain}/${image.still.source} 200`)
       redirects.push(`/${image.thumbnail.url} ${data.filesDomain}/${image.thumbnail.source} 200`)
       // TODO aliases (for renaming to keep respecting the old URL)
     })

--- a/source/_redirects.11ty.js
+++ b/source/_redirects.11ty.js
@@ -2,7 +2,7 @@ class Redirects {
   data() {
     return {
       permalink: (data) => {
-        return "_redirects"
+        return "public/_redirects"
       },
     }
   }

--- a/source/bucket.json.11ty.js
+++ b/source/bucket.json.11ty.js
@@ -2,7 +2,7 @@ class BucketJSON {
   data() {
     return {
       permalink: (data) => {
-        return "images.json"
+        return "public/images.json"
       },
     }
   }

--- a/source/bucket.json.11ty.js
+++ b/source/bucket.json.11ty.js
@@ -2,7 +2,7 @@ class BucketJSON {
   data() {
     return {
       permalink: (data) => {
-        return "public/images.json"
+        return "images.json"
       },
     }
   }

--- a/source/index.webc
+++ b/source/index.webc
@@ -12,8 +12,8 @@ layout: layout
 <ul class="images--container">
   <li webc:for="image of bucket.images" class="images--image" :data-name="image.name" :data-type="image.type">
     <a class="images--image-link" :href="image.original.url">
+      <img class="images--image-thumb" :src="image.still.url" loading="lazy"/>
       <span class="images--image-name" @text="image.name"></span>
-      <img class="images--image-thumb" :src="image.thumbnail.url" loading="lazy"/>
     </a>
   </li>
 </ul>

--- a/source/stylesheets/_bucket.css
+++ b/source/stylesheets/_bucket.css
@@ -1,3 +1,9 @@
+:root {
+  --thumb-width: 135px;
+  --color-overlay-background: #fff;
+  --color-overlay-copy: #333;
+}
+
 .images--filter-input {
   font-size: 100%;
   width: 100%;
@@ -6,23 +12,50 @@
 .images--container {
   display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(40px, 80px));
+  grid-template-columns: repeat(auto-fit, minmax(calc(var(--thumb-width) / 2), var(--thumb-width)));
   list-style-type: none;
   padding: 0;
 }
 
 .images--image {
+  position: relative;
 }
 
+.images--image[data-type="image/gif"]::after {
+  background: gray;
+  border-radius: 0.25rem;
+  color: white;
+  content: "GIF";
+  font-size: 0.5rem;
+  left: 0.25rem;
+  padding: 0.25rem;
+  position: absolute;
+  top: 0.25rem;
+}
+
+
 .images--image-thumb {
-  max-height: 80px;
-  max-width: 80px;
+  max-height: var(--thumb-width);
+  max-width: var(--thumb-width);
 }
 
 .images--image-name {
+  background-color: var(--color-overlay-background);
+  color: var(--color-overlay-copy);
   display: block;
+  height: 100%;
+  opacity: 0;
   overflow: hidden;
+  position: absolute;
   text-overflow: ellipsis;
+  top: 0;
+  visibility: hidden;
   white-space: nowrap;
   width: 100%;
+}
+
+.images--image:hover .images--image-name {
+  transition: opacity 0.5s;
+  opacity: 0.6;
+  visibility: visible;
 }


### PR DESCRIPTION
Because:

- There's like 95MB of even small thumbnails on the page, making it load real slowly—especially on a phone.
- And the grid is silly because the images are different aspect ratios (they fit within 160px box, but aren't all 160px tall on each row), triggering layout shift and a weird-looking list of images.

Solution:

- Use still thumbnails with a GIF badge for animated; click through to see the animation. A future PR might show the full animated thumbnail on hover (like in a slight mini-modal kind of treatment).
- Generate the still thumbs in square aspect ratio regardless of the original's aspect ratio.
- Simplify the JSON a bit by just showing a single thumb and still rather than having support for multiple sizes. Maybe do srcset with multiple image sizes in the future, but for now we just have the 160px version anyway.
